### PR TITLE
Improve validation and update titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# plan-trading-
+# plan trading
+
+Petite application HTML/JS pour suivre les trades et le capital.

--- a/journal_trading.html
+++ b/journal_trading.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8" />
-  <title>Journal de Trading</title>
+  <title>Plan Trading</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <style>
     body {
@@ -94,7 +94,7 @@
   </style>
 </head>
 <body>
-  <h1>Journal de Trading</h1>
+  <h1>Plan Trading</h1>
 
   <div class="capital-box">
     Capital actuel : <input type="number" id="capitalInput" value="1000" step="0.01" /> €
@@ -150,8 +150,19 @@
 
     capitalInput.value = capital.toFixed(2);
 
+    function validateNumber(value, allowNegative = false) {
+      if (isNaN(value)) return false;
+      if (!allowNegative && value < 0) return false;
+      return true;
+    }
+
     capitalInput.addEventListener('change', () => {
-      capital = parseFloat(capitalInput.value);
+      const newCapital = parseFloat(capitalInput.value);
+      if (!validateNumber(newCapital)) {
+        capitalInput.value = capital.toFixed(2);
+        return;
+      }
+      capital = newCapital;
       localStorage.setItem("capital", capital);
     });
 
@@ -194,8 +205,19 @@
       const lot = parseFloat(document.getElementById("lot").value);
       const result = parseFloat(document.getElementById("result").value);
 
-      if (!asset || isNaN(entry) || isNaN(sl) || isNaN(tp) || isNaN(lot) || isNaN(result)) {
+      if (!asset ||
+          !validateNumber(entry) ||
+          !validateNumber(sl) ||
+          !validateNumber(tp) ||
+          !validateNumber(lot) ||
+          !validateNumber(result, true)) {
         errorMsg.textContent = "Merci de remplir tous les champs correctement.";
+        return;
+      }
+
+      const potentialCapital = capital + result;
+      if (potentialCapital < 0) {
+        errorMsg.textContent = "Capital insuffisant pour ce trade.";
         return;
       }
 


### PR DESCRIPTION
## Summary
- update README title and description
- rename page title and heading to "Plan Trading"
- validate numeric inputs for trades and capital
- prevent negative capital values

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68592a888060833181da4eca5b226ad1